### PR TITLE
Magic mode: return Perl's interpretation of the value instead of the literal (#4)

### DIFF
--- a/Bitcoin.pm
+++ b/Bitcoin.pm
@@ -19,7 +19,7 @@ sub import {
 	# This allows magical recognition of bitcoin addresses or keys in
 	# string literals.
 	overload::constant q => sub {
-	    my $s = shift;
+	    my ($s, $perl_s) = @_;
 	    if($s =~ /\A$Bitcoin::Base58::b58 {20,}\z/x) {
 		my ($Base58Data, @error);
 		$Base58Data = eval { new Bitcoin::Key $s };
@@ -30,7 +30,7 @@ sub import {
 		return $Base58Data unless $@;
 		warn "could not convert $s into a bitcoin address or key";
 	    }
-	    return $s;
+	    return $perl_s;
 	};
     }
 }

--- a/EC/DSA.pm
+++ b/EC/DSA.pm
@@ -80,7 +80,7 @@ sub public_key {
 sub random {
     my $this = shift;
     my $i = 0;
-    $i = 256*$i + int rand 256 for 1..32;
+    $i = 256*$i + int Bitcoin::Util::randInt(256) for 1..32;
     $this->new($i);
 }
 


### PR DESCRIPTION
Previously, magic mode meant qq/"-quoted strings behaved like q/'-quoted strings
because it returned the value of the first argument to the overload function
rather than the second.

From the 'overload' perldoc:

The corresponding values are references to functions which take three arguments:
the first one is the initial string form of the constant, the second one is how
Perl interprets this constant, the third one is how the constant is used. Note
that the initial string form does not contain string delimiters, and has
backslashes in backslash-delimiter combinations stripped (thus the value of
delimiter is not relevant for processing of this string). The return value of
this function is how this constant is going to be interpreted by Perl.
